### PR TITLE
Parallelize chunk encoding, encryption, and decryption

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -3,12 +3,17 @@
 
 #include <sodium.h>
 #include <cstring>
+#include <mutex>
 #include <stdexcept>
 
+static std::once_flag sodium_init_flag;
+
 static void ensure_sodium_init() {
-    if (sodium_init() < 0) {
-        throw std::runtime_error("sodium_init failed");
-    }
+    std::call_once(sodium_init_flag, [] {
+        if (sodium_init() < 0) {
+            throw std::runtime_error("sodium_init failed");
+        }
+    });
 }
 
 std::array<std::byte, CRYPTO_KEY_BYTES> derive_key(


### PR DESCRIPTION
This PR parallelizes chunk encoding, encryption, and decryption across the pipeline.

Chunk encoding in Wirehair is parallel in both the CLI and GUI. Previously, only the CLI used OpenMP for the encode loop and now the GUI uses the same parallel loop. Each chunk is handled independently and optional encryption is done first, then encoding. Encryption runs in parallel as part of this loop when it's enabled. Sodium initialization is guarded with a std::call_once so it is safe when the encrypt_chunk is called from multiple threads during parallel encoding.

On the decode side, the decryption loop in assemble_file is parallelized. Chunk sizes are taken from the plaintext size in the header for encrypted chunks or from the chunk data for plain chunks, and a prefix sum array is used to compute offsets into a pre allocated buffer. Each chunk is decrypted in parallel and written into its own slice of the output buffer.
