### PR TITLE
[docs] Documentation clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ GUI. You may need to install some shared libraries (FFmpeg, Qt6, libsodium) to r
 sudo apt update
 sudo apt install cmake build-essential qt6-base-dev \
   libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev \
-  libsodium-dev libomp-dev
+  libsodium-dev libomp-dev ffmpeg
 ```
 
 ### Fedora/CentOS


### PR DESCRIPTION
Added:
- Troubleshooting entry for FFMPEG versions less than 8 causing `Encode Error: failed to write header` errors like #11.
- `ffmpeg` in Ubuntu/Debian installation, for some headless / stripped down editions have no FFMPEG readily installed.

---

Suggestion (not to be taken seriously):
- Rename binaries to `yt-ms`, and `yt-ms-gui`. Just easier to remember this way.
